### PR TITLE
Fixed: These strings use the esc_attr() function and are not translated

### DIFF
--- a/inc/exopite-simple-options/fields/accordion.php
+++ b/inc/exopite-simple-options/fields/accordion.php
@@ -14,7 +14,7 @@ if ( ! class_exists( 'Exopite_Simple_Options_Framework_Field_accordion' ) ) {
 			parent::__construct( $field, $value, $unique, $config, $multilang );
 
 			$this->defaults = array(
-				'section_title'  	=> esc_attr( 'Section Title', 'exopite-sof' ),
+				'section_title'  	=> esc_attr__( 'Section Title', 'exopite-sof' ),
 				'closed'       		=> true,
 				'allow_all_open'	=> true,
 			);

--- a/inc/exopite-simple-options/fields/group.php
+++ b/inc/exopite-simple-options/fields/group.php
@@ -33,14 +33,14 @@ if ( ! class_exists( 'Exopite_Simple_Options_Framework_Field_group' ) ) {
 			parent::__construct( $field, $value, $unique, $config );
 
 			$defaults = array(
-				'group_title'  	=> esc_attr( 'Group Title', 'exopite-sof' ),
+				'group_title'  	=> esc_attr__( 'Group Title', 'exopite-sof' ),
 				'repeater'     	=> false,
 				'cloneable'    	=> true,
 				'sortable'   	=> true,
 				'accordion'    	=> true,
 				'closed'       	=> true,
 				'limit'        	=> 0,
-				'button_title' 	=> esc_attr( 'Add new', 'exopite-sof' ),
+				'button_title' 	=> esc_attr__( 'Add new', 'exopite-sof' ),
 			);
 
 			$options = ( ! empty( $this->field['options'] ) ) ? $this->field['options'] : array();


### PR DESCRIPTION
Fixed: These strings use the esc_attr() function and are not translated

Fix https://wordpress.org/support/topic/these-strings-use-the-esc_attr-function-and-are-not-translated-5/